### PR TITLE
Fix client creation error when one of the auth infos are invalid

### DIFF
--- a/adapter/error.go
+++ b/adapter/error.go
@@ -39,7 +39,7 @@ var (
 	ErrGetName   = errors.NewDefault(ErrGetNameCode, "Unable to get mesh name")
 	ErrOpInvalid = errors.NewDefault(ErrOpInvalidCode, "Invalid operation")
 
-	// ErrAuthInfosInvalidMsg is the error message when the all of auth infos have invalid or inaccessbile paths
+	// ErrAuthInfosInvalidMsg is the error message when the all of auth infos have invalid or inaccessible paths
 	// as there certificate paths
 	ErrAuthInfosInvalidMsg = fmt.Errorf("none of the auth infos are valid either the certificate path is invalid or is inaccessible")
 )

--- a/adapter/error.go
+++ b/adapter/error.go
@@ -38,6 +38,10 @@ const (
 var (
 	ErrGetName   = errors.NewDefault(ErrGetNameCode, "Unable to get mesh name")
 	ErrOpInvalid = errors.NewDefault(ErrOpInvalidCode, "Invalid operation")
+
+	// ErrAuthInfosInvalidMsg is the error message when the all of auth infos have invalid or inaccessbile paths
+	// as there certificate paths
+	ErrAuthInfosInvalidMsg = fmt.Errorf("none of the auth infos are valid either the certificate path is invalid or is inaccessible")
 )
 
 func ErrCreateInstance(err error) error {


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR fixes https://github.com/layer5io/meshery/issues/2134

This PR adds a filtering function which removes invalid authentication infos from he kubeconfig. It will now fail iff all of the auth infos turn out to be invalid.

**Notes for Reviewers**
This fix is added here because the issue is that certificate files may be accessible to the meshery server but may not be accessible to the meshery adapters hence the error would arise again. Filtering the kubeconfig within the adapters will allow each adapter to individually verify if the certificates are accessible to it or not.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
