### PR TITLE
Added support for bearer tokens to authenticate the k8s config

### DIFF
--- a/adapter/configure.go
+++ b/adapter/configure.go
@@ -102,7 +102,7 @@ func (h *Adapter) createKubeconfig(kubeconfig []byte) error {
 // filterK8sConfigAuthInfos takes in the authInfos map and deletes any invalid
 // authInfo.
 //
-// An authInfo is invalid if the certificate path mentioned in it is either
+// An authInfo is invalid if the certificate path or the bearer token path mentioned in it is either
 // invalid or is inaccessible to the adapter
 //
 // The function will throw an error if after filtering the authInfos it becomes
@@ -110,11 +110,13 @@ func (h *Adapter) createKubeconfig(kubeconfig []byte) error {
 // with the kubernetes server.
 func filterK8sConfigAuthInfos(authInfos map[string]*clientcmdapi.AuthInfo) error {
 	for key, authInfo := range authInfos {
-		// If clientCertficateData is not present then proceed to check
+		// If clientCertficateData or the bearer token is not present then proceed to check
 		// the client certicate path
-		if len(authInfo.ClientCertificateData) == 0 && authInfo.AuthProvider == nil {
-			if _, err := os.Stat(authInfo.ClientCertificate); err != nil {
-				// If the path is inaccessible or invalid then delete that authinfo
+		if len(authInfo.ClientCertificateData) == 0 && len(authInfo.Token) == 0 && authInfo.AuthProvider == nil {
+			// If the path for clientCertficate or the bearer token is inaccessible or invalid then delete that authinfo
+			_, errCC := os.Stat(authInfo.ClientCertificate)
+			_, errToken := os.Stat(authInfo.ClientCertificate)
+			if errCC != nil && errToken != nil {
 				delete(authInfos, key)
 			}
 		}

--- a/adapter/configure.go
+++ b/adapter/configure.go
@@ -115,7 +115,7 @@ func filterK8sConfigAuthInfos(authInfos map[string]*clientcmdapi.AuthInfo) error
 		if len(authInfo.ClientCertificateData) == 0 && len(authInfo.Token) == 0 && authInfo.AuthProvider == nil {
 			// If the path for clientCertficate or the bearer token is inaccessible or invalid then delete that authinfo
 			_, errCC := os.Stat(authInfo.ClientCertificate)
-			_, errToken := os.Stat(authInfo.ClientCertificate)
+			_, errToken := os.Stat(authInfo.TokenFile)
 			if errCC != nil && errToken != nil {
 				delete(authInfos, key)
 			}

--- a/adapter/configure.go
+++ b/adapter/configure.go
@@ -113,7 +113,7 @@ func filterK8sConfigAuthInfos(authInfos map[string]*clientcmdapi.AuthInfo) error
 		// If clientCertficateData or the bearer token is not present then proceed to check
 		// the client certicate path
 		if len(authInfo.ClientCertificateData) == 0 && len(authInfo.Token) == 0 && authInfo.AuthProvider == nil {
-			// If the path for clientCertficate or the bearer token is inaccessible or invalid then delete that authinfo
+			// If the path for clientCertficate and the bearer token, both are inaccessible or invalid then delete that authinfo
 			_, errCC := os.Stat(authInfo.ClientCertificate)
 			_, errToken := os.Stat(authInfo.TokenFile)
 			if errCC != nil && errToken != nil {


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

**Description**
This PR adds support for the use of `Bearer Tokens` to authenticate the k8s config.

This PR fixes [#206](https://github.com/layer5io/meshery/issues/206)

**Notes for Reviewers**
Providers like `Digital Ocean` use `Bearer Tokens` instead of `Client Certificates` in their config file, which were not supported by meshery before. This PR should fix it.

Config File with Bearer Tokens

```
users:
- name: do-blr1-k8s-do-admin
  user:
    token: 13asdf9u394vi.....
```

Config with Client Certificates
```
users:
- name: minikube
  user:
    client-certificate-data: LS0tLS1CRUd....
    client-key-data: LS0tLS1CRUdJTiBSU0E.....
```

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
