### PR TITLE
Fix adapter connectivity in k8s

### DIFF
--- a/adapter/configure.go
+++ b/adapter/configure.go
@@ -50,6 +50,12 @@ func (h *Adapter) validateKubeconfig(kubeconfig []byte) error {
 		return ErrValidateKubeconfig(err)
 	}
 
+	// If kubeconfig provided to validate function is empty
+	// and the service is deployed within k8s then skip the validation
+	if len(kubeconfig) == 0 && isDeployedWithinK8s() {
+		return nil
+	}
+
 	if err := filterK8sConfigAuthInfos(h.ClientcmdConfig.AuthInfos); err != nil {
 		return ErrValidateKubeconfig(err)
 	}
@@ -129,4 +135,10 @@ func filterK8sConfigAuthInfos(authInfos map[string]*clientcmdapi.AuthInfo) error
 	}
 
 	return nil
+}
+
+// isDeployedWithinK8s returns true if the adapter is running
+// inside a kubernetes cluster
+func isDeployedWithinK8s() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR fixes adapter connectivity issue when adapter is deployed inside k8s cluster.

Only validation of received kubeconfig is received in case adapter receives an empty kubeconfig and the deployment is within the cluster.
Adapter will automatically read the incluster config in the later stages hence fixing the broken communication.

Tested On:
KinD cluster

**Notes for Reviewers**

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
