### PR TITLE
Replace os.ReadFile with ioutil.ReadFile

### DIFF
--- a/adapter/oam.go
+++ b/adapter/oam.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -88,7 +89,7 @@ func (or *OAMRegistrant) Register() error {
 		}
 		ord.OAMDefinition = definitionMap
 
-		schema, err := os.ReadFile(dpath.OAMRefSchemaPath)
+		schema, err := ioutil.ReadFile(dpath.OAMRefSchemaPath)
 		if err != nil {
 			return ErrOpenOAMRefFile(err)
 		}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**

`os.ReadFile` is not available in golang v1.13 hence this PR is replacing it with `ioutil.ReadFile` (deprecated with go version v1.16)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
