### PR TITLE
update method for reading templates

### DIFF
--- a/adapter/operations.go
+++ b/adapter/operations.go
@@ -38,7 +38,7 @@ func (t Template) String() string {
 		return string(t)
 	}
 
-	st, err := utils.ReadRemoteFile(string(t))
+	st, err := utils.ReadFileSource(string(t))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes #

**Notes for Reviewers**
Updates `template.String()` to use `ReadFileSource()` for reading templates, which supports multiple URI schemes.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
