### PR TITLE
[Chore] Update Golang to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - 'master'
 
 env:
-  go_version: '1.24'
+  go_version: '1.25'
   golangci_version: 'v2.8.0'
 
 jobs:

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Run utility
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-adapter-library
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200806180306-b7e46afd657f
 


### PR DESCRIPTION
**Description**

Fixes #187 by updating Meshery Adapter Library to build with Go 1.25.

**Changes**
- Updated the module directive in `go.mod` from `go 1.24.0` to `go 1.25.0`.
- Updated CI `go_version` from `1.24` to `1.25`.
- Updated the error reference publisher workflow from Go `1.23` to Go `1.25`.

**Notes**
- Go 1.25 is a released stable Go version. The official Go blog announced Go 1.25 on August 12, 2025: https://go.dev/blog/go1.25
- The branch contains one signed-off commit for DCO compliance.

**Testing**
- `git diff --check`
- Verified locally using Go 1.25.10 on Windows/amd64
- `go test ./...`
- `go build ./...`
