### PR TITLE
PR 1.3: Assistant contract inside adapter

### DIFF
--- a/adapter/ai.go
+++ b/adapter/ai.go
@@ -1,0 +1,125 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/layer5io/meshery-adapter-library/meshes"
+)
+
+const (
+	// AIAssistantOperation is the shared operation key for read-only assistant requests.
+	AIAssistantOperation = "ai-assistant-query"
+
+	// AIAssistantCapability identifies adapters that support read-only AI assistant queries.
+	AIAssistantCapability = "ai-assistant"
+)
+
+// AIAssistantHandler is implemented by adapters that support read-only AI assistant queries.
+type AIAssistantHandler interface {
+	QueryAssistant(context.Context, AIAssistantRequest) (AIAssistantResponse, error)
+}
+
+// AIAssistantRequest is the provider-neutral request contract for read-only assistant queries.
+type AIAssistantRequest struct {
+	UserIntent              string          `json:"user_intent"`
+	ProviderConnectionRef   string          `json:"provider_connection_ref,omitempty"`
+	CurrentDesignRef        string          `json:"current_design_ref,omitempty"`
+	CurrentDesignContext    json.RawMessage `json:"current_design_context,omitempty"`
+	SelectedComponentIDs    []string        `json:"selected_component_ids,omitempty"`
+	SchemaScope             []string        `json:"schema_scope,omitempty"`
+	RequestID               string          `json:"request_id,omitempty"`
+	AdditionalContextFields json.RawMessage `json:"additional_context_fields,omitempty"`
+}
+
+// AIAssistantResponse is the provider-neutral response contract for read-only assistant queries.
+type AIAssistantResponse struct {
+	Explanation     string                      `json:"explanation,omitempty"`
+	Recommendations []AIAssistantRecommendation `json:"recommendations,omitempty"`
+	Redirects       []AIAssistantRedirect       `json:"redirects,omitempty"`
+	Errors          []AIAssistantError          `json:"errors,omitempty"`
+	RequestID       string                      `json:"request_id,omitempty"`
+	Metadata        map[string]string           `json:"metadata,omitempty"`
+}
+
+// AIAssistantRecommendation describes a read-only recommendation for the user.
+type AIAssistantRecommendation struct {
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+}
+
+// AIAssistantRedirect points the user to a Meshery resource or documentation page.
+type AIAssistantRedirect struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Type  string `json:"type,omitempty"`
+}
+
+// AIAssistantError is a structured assistant error safe to return to Meshery Server.
+type AIAssistantError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Field   string `json:"field,omitempty"`
+}
+
+// NewAIAssistantOperation returns the standard custom operation advertised by AI-capable adapters.
+func NewAIAssistantOperation() *Operation {
+	return &Operation{
+		Type:        int32(meshes.OpCategory_CUSTOM),
+		Description: "Read-only AI assistant query",
+		Versions:    NoneVersion,
+		Templates:   NoneTemplate,
+		AdditionalProperties: map[string]string{
+			"capability": AIAssistantCapability,
+			"mode":       "read-only",
+		},
+	}
+}
+
+// Validate checks that the assistant request has the minimum required input.
+func (r AIAssistantRequest) Validate() error {
+	if strings.TrimSpace(r.UserIntent) == "" {
+		return errors.New("user_intent is required")
+	}
+	return nil
+}
+
+// Validate checks that the assistant response has exactly one useful output class.
+func (r AIAssistantResponse) Validate() error {
+	outputClasses := 0
+	if strings.TrimSpace(r.Explanation) != "" {
+		outputClasses++
+	}
+	if len(r.Recommendations) > 0 {
+		outputClasses++
+	}
+	if len(r.Redirects) > 0 {
+		outputClasses++
+	}
+	if len(r.Errors) > 0 {
+		outputClasses++
+	}
+	if outputClasses == 0 {
+		return errors.New("assistant response must include explanation, recommendation, redirect, or structured error")
+	}
+	if outputClasses > 1 {
+		return errors.New("assistant response must include only one output class")
+	}
+	return nil
+}

--- a/adapter/ai_test.go
+++ b/adapter/ai_test.go
@@ -1,0 +1,92 @@
+package adapter
+
+import "testing"
+
+func TestNewAIAssistantOperation(t *testing.T) {
+	op := NewAIAssistantOperation()
+	if op == nil {
+		t.Fatal("expected operation")
+	}
+	if op.Description == "" {
+		t.Fatal("expected operation description")
+	}
+	if op.AdditionalProperties["capability"] != AIAssistantCapability {
+		t.Fatalf("expected capability %q, got %q", AIAssistantCapability, op.AdditionalProperties["capability"])
+	}
+	if op.AdditionalProperties["mode"] != "read-only" {
+		t.Fatalf("expected read-only mode, got %q", op.AdditionalProperties["mode"])
+	}
+}
+
+func TestAIAssistantRequestValidate(t *testing.T) {
+	if err := (AIAssistantRequest{}).Validate(); err == nil {
+		t.Fatal("expected missing user intent error")
+	}
+	if err := (AIAssistantRequest{UserIntent: "explain this design"}).Validate(); err != nil {
+		t.Fatalf("expected valid request, got %v", err)
+	}
+}
+
+func TestAIAssistantResponseValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    AIAssistantResponse
+		wantErr bool
+	}{
+		{
+			name:    "empty response",
+			resp:    AIAssistantResponse{},
+			wantErr: true,
+		},
+		{
+			name:    "explanation",
+			resp:    AIAssistantResponse{Explanation: "This design contains one service."},
+			wantErr: false,
+		},
+		{
+			name: "recommendation",
+			resp: AIAssistantResponse{Recommendations: []AIAssistantRecommendation{{
+				Title: "Review service selectors",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "redirect",
+			resp: AIAssistantResponse{Redirects: []AIAssistantRedirect{{
+				Title: "Open Meshery Models",
+				URL:   "/extensions/models",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "structured error",
+			resp: AIAssistantResponse{Errors: []AIAssistantError{{
+				Code:    "CONTEXT_TOO_LARGE",
+				Message: "Narrow the selected context.",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "multiple output classes",
+			resp: AIAssistantResponse{
+				Explanation: "This design contains one service.",
+				Recommendations: []AIAssistantRecommendation{{
+					Title: "Review service selectors",
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resp.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This PR adds a shared read-only AI assistant contract to the adapter library.

It introduces:
- `AIAssistantRequest`
- `AIAssistantResponse`
- `AIAssistantHandler`
- standard `ai-assistant-query` custom operation metadata
- basic request/response validation tests

This is the first shared-contract step for the proposed Meshery AI Adapter work. It does not add provider-specific AI logic, change the existing adapter `Handler` interface, or modify `ApplyRuleResponse`.

This PR is related to [meshery/meshery#19534](https://github.com/meshery/meshery/issues/19534)

**Notes for Reviewers**

The contract is intentionally scoped to read-only assistant behavior: explanation, recommendation, redirect, or structured errors. Design generation, patch candidates, provider clients, and any richer adapter result contract are left for follow-up PRs after design review.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
