### PR TITLE
feat(adapter): add read-only AI assistant contract (1.1)

### DIFF
--- a/adapter/ai.go
+++ b/adapter/ai.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/layer5io/meshery-adapter-library/meshes"
@@ -26,9 +27,6 @@ import (
 const (
 	// AIAssistantOperation is the shared operation key for read-only assistant requests.
 	AIAssistantOperation = "ai-assistant-query"
-
-	// AIAssistantCapability identifies adapters that support read-only AI assistant queries.
-	AIAssistantCapability = "ai-assistant"
 )
 
 // AIAssistantHandler is implemented by adapters that support read-only AI assistant queries.
@@ -78,17 +76,13 @@ type AIAssistantError struct {
 	Field   string `json:"field,omitempty"`
 }
 
-// NewAIAssistantOperation returns the standard custom operation advertised by AI-capable adapters.
+// NewAIAssistantOperation returns the standard custom operation for AI-capable adapters.
 func NewAIAssistantOperation() *Operation {
 	return &Operation{
 		Type:        int32(meshes.OpCategory_CUSTOM),
 		Description: "Read-only AI assistant query",
 		Versions:    NoneVersion,
 		Templates:   NoneTemplate,
-		AdditionalProperties: map[string]string{
-			"capability": AIAssistantCapability,
-			"mode":       "read-only",
-		},
 	}
 }
 
@@ -96,6 +90,12 @@ func NewAIAssistantOperation() *Operation {
 func (r AIAssistantRequest) Validate() error {
 	if strings.TrimSpace(r.UserIntent) == "" {
 		return errors.New("user_intent is required")
+	}
+	if err := validateRawJSON("current_design_context", r.CurrentDesignContext); err != nil {
+		return err
+	}
+	if err := validateRawJSON("additional_context_fields", r.AdditionalContextFields); err != nil {
+		return err
 	}
 	return nil
 }
@@ -120,6 +120,58 @@ func (r AIAssistantResponse) Validate() error {
 	}
 	if outputClasses > 1 {
 		return errors.New("assistant response must include only one output class")
+	}
+	if len(r.Recommendations) > 0 {
+		return validateRecommendations(r.Recommendations)
+	}
+	if len(r.Redirects) > 0 {
+		return validateRedirects(r.Redirects)
+	}
+	if len(r.Errors) > 0 {
+		return validateAssistantErrors(r.Errors)
+	}
+	return nil
+}
+
+func validateRawJSON(field string, raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	if !json.Valid(raw) {
+		return fmt.Errorf("%s must contain valid JSON", field)
+	}
+	return nil
+}
+
+func validateRecommendations(recommendations []AIAssistantRecommendation) error {
+	for i, recommendation := range recommendations {
+		if strings.TrimSpace(recommendation.Title) == "" {
+			return fmt.Errorf("recommendations[%d].title is required", i)
+		}
+	}
+	return nil
+}
+
+func validateRedirects(redirects []AIAssistantRedirect) error {
+	for i, redirect := range redirects {
+		if strings.TrimSpace(redirect.Title) == "" {
+			return fmt.Errorf("redirects[%d].title is required", i)
+		}
+		if strings.TrimSpace(redirect.URL) == "" {
+			return fmt.Errorf("redirects[%d].url is required", i)
+		}
+	}
+	return nil
+}
+
+func validateAssistantErrors(assistantErrors []AIAssistantError) error {
+	for i, assistantError := range assistantErrors {
+		if strings.TrimSpace(assistantError.Code) == "" {
+			return fmt.Errorf("errors[%d].code is required", i)
+		}
+		if strings.TrimSpace(assistantError.Message) == "" {
+			return fmt.Errorf("errors[%d].message is required", i)
+		}
 	}
 	return nil
 }

--- a/adapter/ai.go
+++ b/adapter/ai.go
@@ -1,0 +1,125 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/layer5io/meshery-adapter-library/meshes"
+)
+
+const (
+	// AIAssistantOperation is the shared operation key for read-only assistant requests.
+	AIAssistantOperation = "ai-assistant-query"
+
+	// AIAssistantCapability identifies adapters that support read-only AI assistant queries.
+	AIAssistantCapability = "ai-assistant"
+)
+
+// AIAssistantHandler is implemented by adapters that support read-only AI assistant queries.
+type AIAssistantHandler interface {
+	QueryAssistant(context.Context, AIAssistantRequest) (AIAssistantResponse, error)
+}
+
+// AIAssistantRequest is the provider-neutral request contract for read-only assistant queries.
+type AIAssistantRequest struct {
+	UserIntent              string          `json:"user_intent"`
+	ProviderConnectionRef   string          `json:"provider_connection_ref,omitempty"`
+	CurrentDesignRef        string          `json:"current_design_ref,omitempty"`
+	CurrentDesignContext    json.RawMessage `json:"current_design_context,omitempty"`
+	SelectedComponentIDs    []string        `json:"selected_component_ids,omitempty"`
+	SchemaScope             []string        `json:"schema_scope,omitempty"`
+	RequestID               string          `json:"request_id,omitempty"`
+	AdditionalContextFields json.RawMessage `json:"additional_context_fields,omitempty"`
+}
+
+// AIAssistantResponse is the provider-neutral response contract for read-only assistant queries.
+type AIAssistantResponse struct {
+	Explanation     string                      `json:"explanation,omitempty"`
+	Recommendations []AIAssistantRecommendation `json:"recommendations,omitempty"`
+	Redirects       []AIAssistantRedirect       `json:"redirects,omitempty"`
+	Errors          []AIAssistantError          `json:"errors,omitempty"`
+	RequestID       string                      `json:"request_id,omitempty"`
+	Metadata        map[string]string           `json:"metadata,omitempty"`
+}
+
+// AIAssistantRecommendation describes a read-only recommendation for the user.
+type AIAssistantRecommendation struct {
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+}
+
+// AIAssistantRedirect points the user to a Meshery resource or documentation page.
+type AIAssistantRedirect struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Type  string `json:"type,omitempty"`
+}
+
+// AIAssistantError is a structured assistant error safe to return to Meshery Server.
+type AIAssistantError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Field   string `json:"field,omitempty"`
+}
+
+// NewAIAssistantOperation returns the standard custom operation advertised by AI-capable adapters.
+func NewAIAssistantOperation() *Operation {
+	return &Operation{
+		Type:        int32(meshes.OpCategory_CUSTOM),
+		Description: "Read-only AI assistant query",
+		Versions:    NoneVersion,
+		Templates:   NoneTemplate,
+		AdditionalProperties: map[string]string{
+			"capability": AIAssistantCapability,
+			"mode":       "read-only",
+		},
+	}
+}
+
+// Validate checks that the assistant request has the minimum required input.
+func (r AIAssistantRequest) Validate() error {
+	if strings.TrimSpace(r.UserIntent) == "" {
+		return errors.New("user_intent is required")
+	}
+	return nil
+}
+
+// Validate checks that the assistant response has exactly one useful output class.
+func (r AIAssistantResponse) Validate() error {
+	outputClasses := 0
+	if strings.TrimSpace(r.Explanation) != "" {
+		outputClasses++
+	}
+	if len(r.Recommendations) > 0 {
+		outputClasses++
+	}
+	if len(r.Redirects) > 0 {
+		outputClasses++
+	}
+	if len(r.Errors) > 0 {
+		outputClasses++
+	}
+	if outputClasses == 0 {
+		return errors.New("assistant response must include explanation, recommendation, redirect, or structured error")
+	}
+	if outputClasses > 1 {
+		return errors.New("assistant response must include only one output class")
+	}
+	return nil
+}

--- a/adapter/ai.go
+++ b/adapter/ai.go
@@ -78,11 +78,14 @@ type AIAssistantError struct {
 
 // NewAIAssistantOperation returns the standard custom operation for AI-capable adapters.
 func NewAIAssistantOperation() *Operation {
+	versions := append([]Version(nil), NoneVersion...)
+	templates := append([]Template(nil), NoneTemplate...)
+
 	return &Operation{
 		Type:        int32(meshes.OpCategory_CUSTOM),
 		Description: "Read-only AI assistant query",
-		Versions:    NoneVersion,
-		Templates:   NoneTemplate,
+		Versions:    versions,
+		Templates:   templates,
 	}
 }
 

--- a/adapter/ai_test.go
+++ b/adapter/ai_test.go
@@ -1,0 +1,92 @@
+package adapter
+
+import "testing"
+
+func TestNewAIAssistantOperation(t *testing.T) {
+	op := NewAIAssistantOperation()
+	if op == nil {
+		t.Fatal("expected operation")
+	}
+	if op.Description == "" {
+		t.Fatal("expected operation description")
+	}
+	if op.AdditionalProperties["capability"] != AIAssistantCapability {
+		t.Fatalf("expected capability %q, got %q", AIAssistantCapability, op.AdditionalProperties["capability"])
+	}
+	if op.AdditionalProperties["mode"] != "read-only" {
+		t.Fatalf("expected read-only mode, got %q", op.AdditionalProperties["mode"])
+	}
+}
+
+func TestAIAssistantRequestValidate(t *testing.T) {
+	if err := (AIAssistantRequest{}).Validate(); err == nil {
+		t.Fatal("expected missing user intent error")
+	}
+	if err := (AIAssistantRequest{UserIntent: "explain this design"}).Validate(); err != nil {
+		t.Fatalf("expected valid request, got %v", err)
+	}
+}
+
+func TestAIAssistantResponseValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    AIAssistantResponse
+		wantErr bool
+	}{
+		{
+			name:    "empty response",
+			resp:    AIAssistantResponse{},
+			wantErr: true,
+		},
+		{
+			name:    "explanation",
+			resp:    AIAssistantResponse{Explanation: "This design contains one service."},
+			wantErr: false,
+		},
+		{
+			name: "recommendation",
+			resp: AIAssistantResponse{Recommendations: []AIAssistantRecommendation{{
+				Title: "Review service selectors",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "redirect",
+			resp: AIAssistantResponse{Redirects: []AIAssistantRedirect{{
+				Title: "Open Meshery Models",
+				URL:   "/extensions/models",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "structured error",
+			resp: AIAssistantResponse{Errors: []AIAssistantError{{
+				Code:    "CONTEXT_TOO_LARGE",
+				Message: "Narrow the selected context.",
+			}}},
+			wantErr: false,
+		},
+		{
+			name: "multiple output classes",
+			resp: AIAssistantResponse{
+				Explanation: "This design contains one service.",
+				Recommendations: []AIAssistantRecommendation{{
+					Title: "Review service selectors",
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resp.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/adapter/ai_test.go
+++ b/adapter/ai_test.go
@@ -30,6 +30,14 @@ func TestNewAIAssistantOperation(t *testing.T) {
 	if len(op.AdditionalProperties) != 0 {
 		t.Fatalf("expected no additional properties, got %v", op.AdditionalProperties)
 	}
+	op.Versions[0] = "mutated"
+	op.Templates[0] = "mutated"
+	if NoneVersion[0] == "mutated" {
+		t.Fatal("expected operation versions to be independent from NoneVersion")
+	}
+	if NoneTemplate[0] == "mutated" {
+		t.Fatal("expected operation templates to be independent from NoneTemplate")
+	}
 }
 
 func TestAIAssistantRequestValidate(t *testing.T) {

--- a/adapter/ai_test.go
+++ b/adapter/ai_test.go
@@ -1,6 +1,23 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adapter
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestNewAIAssistantOperation(t *testing.T) {
 	op := NewAIAssistantOperation()
@@ -10,11 +27,8 @@ func TestNewAIAssistantOperation(t *testing.T) {
 	if op.Description == "" {
 		t.Fatal("expected operation description")
 	}
-	if op.AdditionalProperties["capability"] != AIAssistantCapability {
-		t.Fatalf("expected capability %q, got %q", AIAssistantCapability, op.AdditionalProperties["capability"])
-	}
-	if op.AdditionalProperties["mode"] != "read-only" {
-		t.Fatalf("expected read-only mode, got %q", op.AdditionalProperties["mode"])
+	if len(op.AdditionalProperties) != 0 {
+		t.Fatalf("expected no additional properties, got %v", op.AdditionalProperties)
 	}
 }
 
@@ -24,6 +38,30 @@ func TestAIAssistantRequestValidate(t *testing.T) {
 	}
 	if err := (AIAssistantRequest{UserIntent: "explain this design"}).Validate(); err != nil {
 		t.Fatalf("expected valid request, got %v", err)
+	}
+	if err := (AIAssistantRequest{
+		UserIntent:           "explain this design",
+		CurrentDesignContext: json.RawMessage(`{"components":[]}`),
+	}).Validate(); err != nil {
+		t.Fatalf("expected valid current design context, got %v", err)
+	}
+	if err := (AIAssistantRequest{
+		UserIntent:           "explain this design",
+		CurrentDesignContext: json.RawMessage(`{"components":`),
+	}).Validate(); err == nil {
+		t.Fatal("expected invalid current design context error")
+	}
+	if err := (AIAssistantRequest{
+		UserIntent:              "explain this design",
+		AdditionalContextFields: json.RawMessage(`{"scope":[]}`),
+	}).Validate(); err != nil {
+		t.Fatalf("expected valid additional context fields, got %v", err)
+	}
+	if err := (AIAssistantRequest{
+		UserIntent:              "explain this design",
+		AdditionalContextFields: json.RawMessage(`{"scope":`),
+	}).Validate(); err == nil {
+		t.Fatal("expected invalid additional context fields error")
 	}
 }
 
@@ -74,6 +112,27 @@ func TestAIAssistantResponseValidate(t *testing.T) {
 					Title: "Review service selectors",
 				}},
 			},
+			wantErr: true,
+		},
+		{
+			name: "recommendation without title",
+			resp: AIAssistantResponse{Recommendations: []AIAssistantRecommendation{{
+				Description: "Review service selectors.",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "redirect without url",
+			resp: AIAssistantResponse{Redirects: []AIAssistantRedirect{{
+				Title: "Open Meshery Models",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "structured error without message",
+			resp: AIAssistantResponse{Errors: []AIAssistantError{{
+				Code: "CONTEXT_TOO_LARGE",
+			}}},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
**Description**

This PR is part of #209 

Adds the MVP read-only AI assistant contract to `meshery-adapter-library`.

This introduces shared request/response types for AI assistant queries, response validation, and a shared operation registration helper. The response contract is intentionally limited to exactly one output class per response:

- explanation
- recommendation
- documentation/catalog redirect
- structured error

This PR does not add provider routing, prompt/context building, Meshery Server API changes, provisioning, design generation, patch suggestions, or a standalone AI Adapter implementation.

**Notes for Reviewers**
- Added `AIAssistantRequest`, `AIAssistantResponse`, recommendation, redirect, structured error, and `AIAssistantHandler` types.
- Added `NewAIAssistantOperation()` for shared operation registration.
- Added validation for missing `user_intent`, invalid raw JSON context fields, empty responses, missing required response fields, and multiple output classes.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
